### PR TITLE
Debug

### DIFF
--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -73,17 +73,6 @@ class PlotDataObject(DessiaObject):
         return DessiaObject.dict_to_object(dict_=dict_, force_generic=True)
 
 
-# class ColorMapSet(DessiaObject):
-#     def __init__(self, value: float = None, tooltip: bool = False,
-#                  color_range: str = None, selector: bool = True,
-#                  name: str = ''):
-#         self.selector = selector
-#         self.color_range = color_range
-#         self.tooltip = tooltip
-#         self.value = value
-#         DessiaObject.__init__(self, name=name)
-
-
 class HatchingSet(DessiaObject):
     """
     A class for setting hatchings on a surface.
@@ -99,12 +88,6 @@ class HatchingSet(DessiaObject):
         self.stroke_width = stroke_width
         self.hatch_spacing = hatch_spacing
         DessiaObject.__init__(self, name=name)
-
-
-# class ColorSurfaceSet(DessiaObject):
-#     def __init__(self, color: str = 'white', name: str = ''):
-#         self.color = color
-#         DessiaObject.__init__(self, name=name)
 
 
 class Window(DessiaObject):
@@ -571,19 +554,19 @@ class Graph2D(PlotDataObject):
 
     :param graphs: a list of Datasets
     :type graphs: List[Dataset]
-    :param to_disp_attribute_names: [attribute_x, attribute_y] where \
-    attribute_x is the attribute displayed on x-axis and attribute_y \
-    is the attribute displayed on y-axis
-    :type to_disp_attribute_names: [str, str]
+    :param x_variable: variable that you want to display on x axis
+    :type x_variable: str
+    :param y_variable: variable that you want to display on y axis
+    :type y_variable: str
     :param axis: an object containing all information needed for \
     drawing axis
     :type axis: Axis
     """
 
-    def __init__(self, graphs: List[Dataset], to_disp_attribute_names,
+    def __init__(self, graphs: List[Dataset], x_variable: str, y_variable:str,
                  axis: Axis = None, name: str = ''):
         self.graphs = graphs
-        self.to_disp_attribute_names = to_disp_attribute_names
+        self.to_disp_attribute_names = [x_variable, y_variable]
         if axis is None:
             self.axis = Axis()
         else:
@@ -605,6 +588,7 @@ class Graph2D(PlotDataObject):
         ax.set_ylabel(yname)
         return ax
 
+
 class Scatter(PlotDataObject):
     """
     A class for drawing scatter plots.
@@ -612,10 +596,10 @@ class Scatter(PlotDataObject):
     :param elements: A list of vectors. Vectors must have the same \
     attributes (ie the same keys)
     :type elements: List[dict]
-    :param to_disp_attribute_names: [attribute_x, attribute_y] where \
-    attribute_x is the attribute displayed on x-axis and attribute_y \
-    is the attribute displayed on y-axis
-    :type to_disp_attribute_names: [str, str]
+    :param x_variable: variable that you want to display on x axis
+    :type x_variable: str
+    :param y_variable: variable that you want to display on y axis
+    :type y_variable: str
     :param tooltip: an object containing all information needed for \
     drawing tooltips
     :type tooltip: Tooltip
@@ -626,19 +610,19 @@ class Scatter(PlotDataObject):
     :type axis: Axis
     """
 
-    def __init__(self, tooltip: Tooltip,
-                 to_disp_attribute_names: List[str],
+    def __init__(self, x_variable: str, y_variable: str,
+                 tooltip: Tooltip = None,
                  point_style: PointStyle = None,
                  elements: List[Any] = None, axis: Axis = None,
                  name: str = ''):
         self.tooltip = tooltip
-        self.to_disp_attribute_names = to_disp_attribute_names
+        self.to_disp_attribute_names = [x_variable, y_variable]
         self.point_style = point_style
         if not elements:
             self.elements = []
         else:
             self.elements = elements
-        if axis:
+        if not axis:
             self.axis = Axis()
         else:
             self.axis = axis
@@ -857,22 +841,27 @@ class PrimitiveGroupsContainer(PlotDataObject):
     primitive_groups[i]. It only works if this object is inside a \
     MultiplePlots.
     :type associated_elements: List[int]
-    :param to_disp_attribute_names: A list containing the attribute \
-    names to be displayed on axis. It may contain one or two names. ex:\
-     ['mass'] or ['length', 'mass']. Set it to None for no axis.
-    :type to_disp_attribute_names: List[str]
+    :param x_variable: variable that you want to display on x axis
+    :type x_variable: str
+    :param y_variable: variable that you want to display on y axis
+    :type y_variable: str
     """
 
     def __init__(self, primitive_groups: List[PrimitiveGroup],
                  sizes: List[Tuple[float, float]] = None,
                  coords: List[Tuple[float, float]] = None,
                  associated_elements: List[int] = None,
-                 to_disp_attribute_names: List[str] = None,
+                 x_variable: str = None, y_variable: str = None,
                  name: str = ''):
         self.primitive_groups = primitive_groups
         self.sizes = sizes
         self.coords = coords
-        if to_disp_attribute_names:
+        if x_variable or y_variable:
+            to_disp_attribute_names = []
+            if x_variable:
+                to_disp_attribute_names.append(x_variable)
+            if (y_variable):
+                to_disp_attribute_names.append(y_variable)
             self.association = {'associated_elements': associated_elements,
                                 'to_disp_attribute_names': to_disp_attribute_names}
         PlotDataObject.__init__(self, type_='primitivegroupcontainer',

--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -855,6 +855,9 @@ class PrimitiveGroupsContainer(PlotDataObject):
                  associated_elements: List[int] = None,
                  x_variable: str = None, y_variable: str = None,
                  name: str = ''):
+        for i, value in enumerate(primitive_groups):
+            if not str(value.__class__) == "<class 'plot_data.core.PrimitiveGroup'>":
+                primitive_groups[i] = PrimitiveGroup(primitives=value)
         self.primitive_groups = primitive_groups
         self.sizes = sizes
         self.coords = coords

--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -104,14 +104,14 @@ class EdgeStyle(DessiaObject):
     :param line_width: line width in pixels.
     :type line_width: float
     :param color_stroke: the edge's color (rgb255).
-    :type color_stroke: str
+    :type color_stroke: plot_data.Colors.Color
     :param dashline: a list of positive floats [a1,...,an] representing \
     a pattern where a_2i is the number of solid pixels and a_2i+1 is \
     the number of empty pixels.
     :type dashline: List[float]
     """
 
-    def __init__(self, line_width: float = None, color_stroke: str = None,
+    def __init__(self, line_width: float = None, color_stroke: colors.Color = None,
                  dashline: List[int] = None, name: str = ''):
         self.line_width = line_width
         self.color_stroke = color_stroke
@@ -256,16 +256,17 @@ class Line2D(PlotDataObject):
     An infinite line. Line2D is a primitive and can be instantiated by \
     PrimitiveGroups.
 
-    :param data: [x1, y1, x2, y2] where (x1, y1) and (x2, y2) are two \
-    points that belong to the line.
-    :type data: [float, float, float, float]
+    :param point1: first endpoint of the line segment [x1, y1].
+    :type point1: List[float]
+    :param point2: first endpoint of the line segment [x2, y2].
+    :type point2: List[float]
     :param edge_style: for customization
     :type edge_style: EdgeStyle
     """
 
-    def __init__(self, data: List[float], edge_style: EdgeStyle = None,
-                 name: str = ''):
-        self.data = data
+    def __init__(self, point1: List[float], point2: List[float],
+                 edge_style: EdgeStyle = None, name: str = ''):
+        self.data = point1 + point2
         self.edge_style = edge_style
         PlotDataObject.__init__(self, type_='line2d', name=name)
 
@@ -292,16 +293,18 @@ class LineSegment2D(PlotDataObject):
     A line segment. This is a primitive that can be called by \
     PrimitiveGroup.
 
-    :param data: [x1, y1, x2, y2] where (x1, y1) and (x2, y2) are two \
-    points that belong to the line segment.
-    :type data: [float, float, float, float]
+    :param point1: first endpoint of the line segment [x1, y1].
+    :type point1: List[float]
+    :param point2: first endpoint of the line segment [x2, y2].
+    :type point2: List[float]
     :param edge_style: for customization
     :type edge_style: EdgeStyle
     """
 
-    def __init__(self, data: List[float], edge_style: EdgeStyle = None,
+    def __init__(self, point1: List[float], point2: List[float],
+                 edge_style: EdgeStyle = None,
                  name: str = ''):
-        self.data = data
+        self.data = point1 + point2
         if edge_style is None:
             self.edge_style = EdgeStyle()
         else:
@@ -366,8 +369,8 @@ class Circle2D(PlotDataObject):
         self.edge_style = edge_style
         self.surface_style = surface_style
         self.r = r
-        self.cy = cy
         self.cx = cx
+        self.cy = cy
         PlotDataObject.__init__(self, type_='circle', name=name)
 
     def bounding_box(self):
@@ -633,7 +636,7 @@ class Scatter(PlotDataObject):
 class Arc2D(PlotDataObject):
     """
     A class for drawing arcs. Arc2D is a primitive and can be \
-    instantiated by PrimitiveGroup.
+    instantiated by PrimitiveGroup. By default, the arc is drawn anticlockwise.
 
     :param cx: the arc center's x position
     :type cx: float
@@ -728,9 +731,8 @@ class Contour2D(PlotDataObject):
         for plot_data_primitive in self.plot_data_primitives:
             if hasattr(plot_data_primitive, 'bounding_box'):
                 bb = plot_data_primitive.bounding_box()
-                xmin, xmax, ymin, ymax = min(xmin, bb[0]), max(xmax,
-                                                               bb[1]), min(
-                    ymin, bb[2]), max(ymax, bb[3])
+                xmin, xmax, ymin, ymax = min(xmin, bb[0]), max(xmax,bb[1]), \
+                                         min(ymin, bb[2]), max(ymax, bb[3])
 
         return xmin, xmax, ymin, ymax
 
@@ -837,7 +839,7 @@ class PrimitiveGroupsContainer(PlotDataObject):
     :param coords: In the same way as sizes but for coordinates.
     :type coords: List[Tuple[float, float]]
     :param associated_elements: A list containing the associated \
-    elements indices. associated_elements[i] is assoaciated with \
+    elements indices. associated_elements[i] is associated with \
     primitive_groups[i]. It only works if this object is inside a \
     MultiplePlots.
     :type associated_elements: List[int]
@@ -860,7 +862,7 @@ class PrimitiveGroupsContainer(PlotDataObject):
             to_disp_attribute_names = []
             if x_variable:
                 to_disp_attribute_names.append(x_variable)
-            if (y_variable):
+            if y_variable:
                 to_disp_attribute_names.append(y_variable)
             self.association = {'associated_elements': associated_elements,
                                 'to_disp_attribute_names': to_disp_attribute_names}
@@ -880,9 +882,9 @@ class ParallelPlot(PlotDataObject):
     :param disposition: either 'vertical' or 'horizontal' depending on \
     how you want the initial disposition to be.
     :type disposition: str
-    :param to_disp_attribute_names: a list on attribute names you want \
+    :param axes: a list on attribute names you want \
     to display as axis on this parallel plot.
-    :type to_disp_attribute_names: List[str]
+    :type axes: List[str]
     :param rgbs: a list of rgb255 colors for color interpolation. Color\
      interpolation is enabled when clicking on an axis.
     :type rgbs: List[Tuple[int, int, int]]
@@ -890,13 +892,13 @@ class ParallelPlot(PlotDataObject):
 
     def __init__(self, elements=None, edge_style: EdgeStyle = None,
                  disposition: str = None,
-                 to_disp_attribute_names: List[str] = None,
+                 axes: List[str] = None,
                  rgbs: List[Tuple[int, int, int]] = None,
                  name: str = ''):
         self.elements = elements
         self.edge_style = edge_style
         self.disposition = disposition
-        self.to_disp_attribute_names = to_disp_attribute_names
+        self.to_disp_attribute_names = axes
         self.rgbs = rgbs
         PlotDataObject.__init__(self, type_='parallelplot', name=name)
 

--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -856,7 +856,7 @@ class PrimitiveGroupsContainer(PlotDataObject):
                  x_variable: str = None, y_variable: str = None,
                  name: str = ''):
         for i, value in enumerate(primitive_groups):
-            if not str(value.__class__) == "<class 'plot_data.core.PrimitiveGroup'>":
+            if not isinstance(value, PrimitiveGroup):
                 primitive_groups[i] = PrimitiveGroup(primitives=value)
         self.primitive_groups = primitive_groups
         self.sizes = sizes

--- a/script/multiple_plots.py
+++ b/script/multiple_plots.py
@@ -32,19 +32,13 @@ parallelplot1 = plot_data.ParallelPlot(
 parallelplot2 = plot_data.ParallelPlot(to_disp_attribute_names=['x', 'color'])
 
 # Scatterplots
-scatterplot1 = plot_data.Scatter(
-    tooltip=plot_data.Tooltip(to_disp_attribute_names=['x', 'direction']),
-    to_disp_attribute_names=['x', 'y'])
+scatterplot1 = plot_data.Scatter(x_variable='x', y_variable='y')
 
-scatterplot2 = plot_data.Scatter(
-    tooltip=plot_data.Tooltip(to_disp_attribute_names=['y', 'color']),
-    to_disp_attribute_names=['y', 'color'],
-    point_style=plot_data.PointStyle(
-        shape='square'))  # optional argument that changes points' appearance
+scatterplot2 = plot_data.Scatter(x_variable='y', y_variable='color',
+                                 point_style=plot_data.PointStyle(shape='square'))  # optional argument that changes
+# points' appearance
 
-scatterplot3 = plot_data.Scatter(
-    tooltip=plot_data.Tooltip(to_disp_attribute_names=['x', 'direction']),
-    to_disp_attribute_names=['x', 'direction'])
+scatterplot3 = plot_data.Scatter(x_variable='x', y_variable='direction')
 
 # PrimitiveGroupContainers
 circle1 = vm.wires.Circle2D(vm.Point2D(0, 0), 10).plot_data()
@@ -67,8 +61,7 @@ primitive_groups = [primitive_group1, primitive_group2, primitive_group3, primit
 
 primitive_group_container = plot_data.PrimitiveGroupsContainer(primitive_groups=primitive_groups,
                                                                associated_elements=[1, 2, 3, 4],
-                                                               to_disp_attribute_names=['x', 'y']
-                                                               )
+                                                               x_variable='x', y_variable='y')
 
 
 # Creating the multiplot

--- a/script/multiple_plots.py
+++ b/script/multiple_plots.py
@@ -16,10 +16,10 @@ elements = []  # a list of vectors (dictionaries) that are displayed
 # through different representations such as parallel plots and scatter plots
 
 nb_elements = 50
-colors = [colors.VIOLET, colors.BLUE, colors.GREEN, colors.RED, colors.YELLOW, colors.CYAN, colors.ROSE]
+available_colors = [colors.VIOLET, colors.BLUE, colors.GREEN, colors.RED, colors.YELLOW, colors.CYAN, colors.ROSE]
 directions = ['north', 'south', 'west', 'east']
 for i in range(nb_elements):
-    random_color = colors[random.randint(0, len(colors) - 1)]
+    random_color = available_colors[random.randint(0, len(available_colors) - 1)]
     random_direction = directions[random.randint(0, len(directions) - 1)]
     elements.append({'x': random.uniform(0, 200),
                      'y': random.uniform(0, 100),
@@ -40,22 +40,22 @@ scatterplot2 = plot_data.Scatter(x_variable='y', y_variable='color',
 scatterplot3 = plot_data.Scatter(x_variable='x', y_variable='direction')
 
 # PrimitiveGroupContainers
-circle1 = vm.wires.Circle2D(vm.Point2D(0, 0), 10).plot_data()
+circle1 = vm.wires.Circle2D([0, 0], 10).plot_data()
 
-l1 = vm.edges.LineSegment2D(vm.Point2D(1, 1), vm.Point2D(1, 2))
-l2 = vm.edges.LineSegment2D(vm.Point2D(1, 2), vm.Point2D(2, 2))
-l3 = vm.edges.LineSegment2D(vm.Point2D(2, 2), vm.Point2D(2, 1))
-l4 = vm.edges.LineSegment2D(vm.Point2D(2, 1), vm.Point2D(1, 1))
+l1 = vm.edges.LineSegment2D([1, 1], [1, 2])
+l2 = vm.edges.LineSegment2D([1, 2], [2, 2])
+l3 = vm.edges.LineSegment2D([2, 2], [2, 1])
+l4 = vm.edges.LineSegment2D([2, 1], [1, 1])
 contour = vm.wires.Contour2D([l1, l2, l3, l4]).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.LIGHTORANGE))
 
-circle2 = vm.wires.Circle2D(vm.Point2D(1, 1), 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.RED))
+circle2 = vm.wires.Circle2D([1, 1], 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.RED))
 
-circle3 = vm.wires.Circle2D(vm.Point2D(1, 1), 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.LIGHTBROWN))
+circle3 = vm.wires.Circle2D([1, 1], 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.LIGHTBROWN))
 
-primitive_group1 = plot_data.PrimitiveGroup(primitives=[circle1])
-primitive_group2 = plot_data.PrimitiveGroup(primitives=[contour])
-primitive_group3 = plot_data.PrimitiveGroup(primitives=[circle2])
-primitive_group4 = plot_data.PrimitiveGroup(primitives=[circle3])
+primitive_group1 = [circle1]
+primitive_group2 = [contour]
+primitive_group3 = [circle2]
+primitive_group4 = [circle3]
 primitive_groups = [primitive_group1, primitive_group2, primitive_group3, primitive_group4]
 
 primitive_group_container = plot_data.PrimitiveGroupsContainer(primitive_groups=primitive_groups,

--- a/script/multiple_plots.py
+++ b/script/multiple_plots.py
@@ -2,21 +2,21 @@
 # different plots in one canvas, including scatterplots, parallelplots,
 # primitive_groups and primitive_group_containers.
 # The plots are created using necessary parameters only. For more details about
-# customization an optional parameters, feel free read the plots' specific scripts.
+# customization and optional parameters, feel free read the plots' specific scripts.
 
 import plot_data
-from plot_data.colors import *
+import plot_data.colors as colors
 from test_objects.primitive_group_test import primitive_group
 from test_objects.graph_test import graph2d
 import random
 
-import volmdlr as vm  # You can install volmdlr using pip in plot_data's package
+import volmdlr as vm  # You can install volmdlr using pip
 
 elements = []  # a list of vectors (dictionaries) that are displayed
 # through different representations such as parallel plots and scatter plots
 
 nb_elements = 50
-colors = [VIOLET, BLUE, GREEN, RED, YELLOW, CYAN, ROSE]
+colors = [colors.VIOLET, colors.BLUE, colors.GREEN, colors.RED, colors.YELLOW, colors.CYAN, colors.ROSE]
 directions = ['north', 'south', 'west', 'east']
 for i in range(nb_elements):
     random_color = colors[random.randint(0, len(colors) - 1)]
@@ -27,16 +27,15 @@ for i in range(nb_elements):
                      'direction': random_direction})
 
 # ParallelPlot
-parallelplot1 = plot_data.ParallelPlot(
-    to_disp_attribute_names=['x', 'y', 'color', 'direction'])
-parallelplot2 = plot_data.ParallelPlot(to_disp_attribute_names=['x', 'color'])
+parallelplot1 = plot_data.ParallelPlot(axes=['x', 'y', 'color', 'direction'])
+parallelplot2 = plot_data.ParallelPlot(axes=['x', 'color'])
 
 # Scatterplots
 scatterplot1 = plot_data.Scatter(x_variable='x', y_variable='y')
 
 scatterplot2 = plot_data.Scatter(x_variable='y', y_variable='color',
                                  point_style=plot_data.PointStyle(shape='square'))  # optional argument that changes
-# points' appearance
+                                                                                    # points' appearance
 
 scatterplot3 = plot_data.Scatter(x_variable='x', y_variable='direction')
 
@@ -47,11 +46,11 @@ l1 = vm.edges.LineSegment2D(vm.Point2D(1, 1), vm.Point2D(1, 2))
 l2 = vm.edges.LineSegment2D(vm.Point2D(1, 2), vm.Point2D(2, 2))
 l3 = vm.edges.LineSegment2D(vm.Point2D(2, 2), vm.Point2D(2, 1))
 l4 = vm.edges.LineSegment2D(vm.Point2D(2, 1), vm.Point2D(1, 1))
-contour = vm.wires.Contour2D([l1, l2, l3, l4]).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=LIGHTORANGE))
+contour = vm.wires.Contour2D([l1, l2, l3, l4]).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.LIGHTORANGE))
 
-circle2 = vm.wires.Circle2D(vm.Point2D(1, 1), 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=RED))
+circle2 = vm.wires.Circle2D(vm.Point2D(1, 1), 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.RED))
 
-circle3 = vm.wires.Circle2D(vm.Point2D(1, 1), 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=LIGHTBROWN))
+circle3 = vm.wires.Circle2D(vm.Point2D(1, 1), 5).plot_data(surface_style=plot_data.SurfaceStyle(color_fill=colors.LIGHTBROWN))
 
 primitive_group1 = plot_data.PrimitiveGroup(primitives=[circle1])
 primitive_group2 = plot_data.PrimitiveGroup(primitives=[contour])

--- a/script/parallel_plot.py
+++ b/script/parallel_plot.py
@@ -15,12 +15,9 @@ for i in range(50):
                      })
 
 parallelplot = plot_data.ParallelPlot(elements=elements,
-                                      to_disp_attribute_names=['mass',
-                                                               'length',
-                                                               'shape',
-                                                               'color'])
+                                      axes=['mass', 'length', 'shape', 'color'])
 
-# The previous script is actually the minimum requirement for creating a
+# The line above shows the minimum requirement for creating a
 # parallel plot. However, many options are available for further customization.
 
 # 'edge_style' option allows customization of the lines
@@ -39,10 +36,7 @@ disposition = 'horizontal'
 rgbs = [BLUE, YELLOW, ORANGE]
 
 customized_parallelplot = plot_data.ParallelPlot(elements=elements,
-                                                 to_disp_attribute_names=['mass',
-                                                                          'length',
-                                                                          'shape',
-                                                                          'color'],
+                                                 axes=['mass', 'length', 'shape', 'color'],
                                                  edge_style=edge_style,
                                                  disposition=disposition,
                                                  rgbs=rgbs)

--- a/script/parallel_plot.py
+++ b/script/parallel_plot.py
@@ -17,7 +17,7 @@ for i in range(50):
 parallelplot = plot_data.ParallelPlot(elements=elements,
                                       axes=['mass', 'length', 'shape', 'color'])
 
-# The line above shows the minimum requirement for creating a
+# The line above shows the minimum requirements for creating a
 # parallel plot. However, many options are available for further customization.
 
 # 'edge_style' option allows customization of the lines

--- a/script/scatter_plot.py
+++ b/script/scatter_plot.py
@@ -20,11 +20,10 @@ for i in range(50):
 tooltip = plot_data.Tooltip(to_disp_attribute_names=['mass', 'length'])
 
 scatterplot = plot_data.Scatter(elements=elements,
-                                to_disp_attribute_names=['mass', 'length'],
-                                tooltip=tooltip)
+                                x_variable='mass', y_variable='length')
 
 # The previous scripts actually shows the simplest way of creating a scatterplot.
-# However, many options are available for futher customization
+# However, many options are available for further customization
 
 # First of all, apart from tooltips' information, the user can customize
 # the style. 'text_style' modifies the text while 'surface_style'
@@ -59,8 +58,7 @@ axis = plot_data.Axis(nb_points_x=7, nb_points_y=5,
                       )
 
 # Now, here is the new scatterplot
-customized_scatterplot = plot_data.Scatter(tooltip=tooltip,
-                                           to_disp_attribute_names=['mass', 'shape'],
+customized_scatterplot = plot_data.Scatter(x_variable='mass', y_variable='shape',
                                            point_style=point_style,
                                            elements=elements,
                                            axis=axis)

--- a/script/scatter_plot.py
+++ b/script/scatter_plot.py
@@ -1,11 +1,11 @@
 import plot_data
-from plot_data.colors import *
+import plot_data.colors as colors
 import random
 # A script showing scatter plots instantiations.
 
 elements = []
 SHAPES = ['round', 'square', 'triangle', 'ellipse']
-COLORS = [RED, BLUE, GREEN, YELLOW, ORANGE, VIOLET]
+COLORS = [colors.RED, colors.BLUE, colors.GREEN, colors.YELLOW, colors.ORANGE, colors.VIOLET]
 for i in range(50):
     random_shape = SHAPES[random.randint(0, len(SHAPES) - 1)]
     random_color = COLORS[random.randint(0, len(SHAPES) - 1)]
@@ -15,24 +15,21 @@ for i in range(50):
                      'color': random_color
                      })
 
-# a tooltip is drawn when clicking on a point. Users can choose what information
-# they want to be displayed.
-tooltip = plot_data.Tooltip(to_disp_attribute_names=['mass', 'length'])
 
 scatterplot = plot_data.Scatter(elements=elements,
                                 x_variable='mass', y_variable='length')
 
-# The previous scripts actually shows the simplest way of creating a scatterplot.
+# The previous scripts shows the simplest way of creating a scatterplot.
 # However, many options are available for further customization
 
 # First of all, apart from tooltips' information, the user can customize
 # the style. 'text_style' modifies the text while 'surface_style'
 # changes the tooltip's interior. Tooltips are rounded-rectangle-shaped and the radius of the
 # vertices can also be changed.
-text_style = plot_data.TextStyle(text_color=GREY,
+text_style = plot_data.TextStyle(text_color=colors.GREY,
                                  font_size=10,
                                  font_style='sans-serif')
-surface_style = plot_data.SurfaceStyle(color_fill=LIGHTVIOLET, opacity=0.3)
+surface_style = plot_data.SurfaceStyle(color_fill=colors.LIGHTVIOLET, opacity=0.3)
 custom_tooltip = plot_data.Tooltip(to_disp_attribute_names=['mass', 'length'],
                                    surface_style=surface_style,
                                    text_style=text_style,
@@ -40,16 +37,17 @@ custom_tooltip = plot_data.Tooltip(to_disp_attribute_names=['mass', 'length'],
 
 
 # Then, points' appearance can be modified through point_style attribute
-point_style = plot_data.PointStyle(color_fill=LIGHTGREEN,
-                                   color_stroke=VIOLET,
+point_style = plot_data.PointStyle(color_fill=colors.LIGHTGREEN,
+                                   color_stroke=colors.VIOLET,
                                    stroke_width=0.5,
                                    size=2,  # 1, 2, 3 or 4
                                    shape='circle')  # 'circle', 'square' or 'crux'
 
 # Finally, axis can be personalized too
-graduation_style = plot_data.TextStyle(text_color=BLUE, font_size=10,
+graduation_style = plot_data.TextStyle(text_color=colors.BLUE, font_size=10,
                                        font_style='Arial')
-axis_style = plot_data.EdgeStyle(line_width=0.5, color_stroke=ROSE,
+
+axis_style = plot_data.EdgeStyle(line_width=0.5, color_stroke=colors.ROSE,
                                  dashline=[])
 
 axis = plot_data.Axis(nb_points_x=7, nb_points_y=5,
@@ -57,11 +55,17 @@ axis = plot_data.Axis(nb_points_x=7, nb_points_y=5,
                       axis_style=axis_style
                       )
 
+# a tooltip is drawn when clicking on a point. Users can choose what information
+# they want to be displayed.
+tooltip = plot_data.Tooltip(to_disp_attribute_names=['mass', 'length', 'shape', 'color'])
+
+
 # Now, here is the new scatterplot
 customized_scatterplot = plot_data.Scatter(x_variable='mass', y_variable='shape',
                                            point_style=point_style,
                                            elements=elements,
-                                           axis=axis)
+                                           axis=axis,
+                                           tooltip=tooltip)
 
 # if debug_mode is True, set it to False
 plot_data.plot_canvas(plot_data_object=customized_scatterplot, debug_mode=True)

--- a/script/test_objects/graph_test.py
+++ b/script/test_objects/graph_test.py
@@ -7,8 +7,6 @@ import numpy as np
 
 k = 0
 
-to_disp_attribute_names = ['time', 'electric current']
-tooltip = plot_data.Tooltip(to_disp_attribute_names=to_disp_attribute_names)
 T1 = np.linspace(0, 20, 20)
 I1 = [t ** 2 for t in T1]
 elements1 = []
@@ -23,7 +21,7 @@ point_style = plot_data.PointStyle(color_fill=RED, color_stroke=BLACK)
 edge_style = plot_data.EdgeStyle(color_stroke=BLUE, dashline=[10, 5])
 
 custom_dataset = plot_data.Dataset(elements=elements1, name='I = f(t)',
-                                   tooltip=tooltip, point_style=point_style,
+                                   point_style=point_style,
                                    edge_style=edge_style)
 
 
@@ -38,4 +36,4 @@ dataset2 = plot_data.Dataset(elements=elements2, name='I2 = f(t)')
 
 
 graph2d = plot_data.Graph2D(graphs=[custom_dataset, dataset2],
-                            to_disp_attribute_names=to_disp_attribute_names)
+                            x_variable='time', y_variable='electric current')

--- a/script/test_objects/primitive_group_test.py
+++ b/script/test_objects/primitive_group_test.py
@@ -7,15 +7,15 @@ import numpy as npy
 import volmdlr as vm  # You can install volmdlr using pip in plot_data's package
 import volmdlr.edges
 import volmdlr.wires
-from plot_data.colors import *
+import plot_data.colors as colors
 
 
 # defining a couple style objects
     # edges customization
-edge_style = plot_data.EdgeStyle(line_width=1, color_stroke=RED, dashline=[])
+edge_style = plot_data.EdgeStyle(line_width=1, color_stroke=colors.RED, dashline=[])
     # surfaces customization
 hatching = plot_data.HatchingSet(0.5, 3)
-surface_style = plot_data.SurfaceStyle(color_fill=WHITE, opacity=1,
+surface_style = plot_data.SurfaceStyle(color_fill=colors.WHITE, opacity=1,
                                        hatching=hatching)
 
 
@@ -33,37 +33,32 @@ plot_data_arc = arc.plot_data(edge_style=edge_style)
 
 # square contour
 rectangle_size = 1
-pt1 = vm.Point2D(0, 0)
-pt2 = vm.Point2D(0, rectangle_size)
-pt3 = vm.Point2D(rectangle_size, rectangle_size)
-pt4 = vm.Point2D(rectangle_size, 0)
-contour1 = vm.wires.Contour2D([vm.edges.LineSegment2D(pt1, pt2),
-                               vm.edges.LineSegment2D(pt2, pt3),
-                               vm.edges.LineSegment2D(pt3, pt4),
-                               vm.edges.LineSegment2D(pt4, pt1)])
+contour1 = vm.wires.Contour2D([vm.edges.LineSegment2D([0, 0], [0, rectangle_size]),
+                               vm.edges.LineSegment2D([0, rectangle_size], [rectangle_size, rectangle_size]),
+                               vm.edges.LineSegment2D([rectangle_size, rectangle_size], [rectangle_size, 0]),
+                               vm.edges.LineSegment2D([rectangle_size, 0], [0, 0])])
 
 plot_data_contour = contour1.plot_data(edge_style=edge_style,
                                        surface_style=surface_style)
 
 
 # LineSegment2D
-plot_data_line = vm.edges.LineSegment2D(vm.Point2D(2, 2),
-                                        vm.Point2D(3, 3)).plot_data(edge_style)
+plot_data_line = vm.edges.LineSegment2D([2, 2], [3, 3]).plot_data(edge_style)
 
 
 # Circle
-circle_edge_style = plot_data.EdgeStyle(1, RED)
-circle_surface_style = plot_data.SurfaceStyle(color_fill=YELLOW, opacity=0.5,
+circle_edge_style = plot_data.EdgeStyle(1, colors.RED)
+circle_surface_style = plot_data.SurfaceStyle(color_fill=colors.YELLOW, opacity=0.5,
                                               hatching=plot_data.HatchingSet())
 
-circle = vm.wires.Circle2D(vm.Point2D(5, 9), 5)
+circle = vm.wires.Circle2D([5, 9], 5)
 plot_data_circle = circle.plot_data(edge_style=circle_edge_style,
                                     surface_style=circle_surface_style)
 
 
 # Text
 text = plot_data.Text(comment='Hello', position_x=6, position_y=9,
-                      text_style=plot_data.TextStyle(text_color=RED,
+                      text_style=plot_data.TextStyle(text_color=colors.RED,
                                                      font_size=12,
                                                      font_style='sans-serif')
                       )
@@ -73,9 +68,9 @@ text = plot_data.Text(comment='Hello', position_x=6, position_y=9,
 label1 = plot_data.Label(title='label1')
 
   # This label is created using all customizations
-fill1 = plot_data.SurfaceStyle(color_fill=RED, opacity=0.5)
-edge1 = plot_data.EdgeStyle(line_width=1, color_stroke=BLUE, dashline=[5, 5])
-text_style = plot_data.TextStyle(text_color=ORANGE, font_size=14, italic=True, bold=True)
+fill1 = plot_data.SurfaceStyle(color_fill=colors.RED, opacity=0.5)
+edge1 = plot_data.EdgeStyle(line_width=1, color_stroke=colors.BLUE, dashline=[5, 5])
+text_style = plot_data.TextStyle(text_color=colors.ORANGE, font_size=14, italic=True, bold=True)
 label2 = plot_data.Label(title='label2', text_style=text_style, rectangle_surface_style=fill1,
                          rectangle_edge_style=edge1)
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1954,8 +1954,8 @@ export abstract class PlotData {
     if (d['type_'] == 'primitivegroup') {
       for (let i=0; i<d.primitives.length; i++) {
         this.context.beginPath();
-        let pr_x=scaleX*(1000*d.primitives[i].minX + mvx) + this.X; 
-        let pr_y=scaleY*(1000*d.primitives[i].minY + mvy) + this.Y;
+        let pr_x=scaleX*(1000*d.primitives[i].minX + mvx); 
+        let pr_y=scaleY*(1000*d.primitives[i].minY + mvy);
         let pr_w=scaleX*1000*(d.primitives[i].maxX - d.primitives[i].minX);
         let pr_h=scaleY*1000*(d.primitives[i].maxY - d.primitives[i].minY);
         var is_inside_canvas = (pr_x+pr_w>=0) && (pr_x<=this.width) &&

--- a/src/core.ts
+++ b/src/core.ts
@@ -1954,11 +1954,12 @@ export abstract class PlotData {
     if (d['type_'] == 'primitivegroup') {
       for (let i=0; i<d.primitives.length; i++) {
         this.context.beginPath();
-        let pr_x=this.scale*(1000*d.primitives[i].minX + mvx); let pr_y=this.scale*(1000*d.primitives[i].minY + mvy);
-        let pr_w=this.scale*1000*(d.primitives[i].maxX - d.primitives[i].minX);
-        let pr_h=this.scale*1000*(d.primitives[i].maxY - d.primitives[i].minY);
+        let pr_x=scaleX*(1000*d.primitives[i].minX + mvx) + this.X; 
+        let pr_y=scaleY*(1000*d.primitives[i].minY + mvy) + this.Y;
+        let pr_w=scaleX*1000*(d.primitives[i].maxX - d.primitives[i].minX);
+        let pr_h=scaleY*1000*(d.primitives[i].maxY - d.primitives[i].minY);
         var is_inside_canvas = (pr_x+pr_w>=0) && (pr_x<=this.width) &&
-          (pr_y+pr_h>=0) && (pr_y<=this.height);
+          (pr_y+pr_h>0) && (pr_y<=this.height);
         if (need_check.includes(d.primitives[i].type_) && !is_inside_canvas) continue;
         if (d.primitives[i].type_ == 'contour') {
           this.draw_contour(hidden, mvx, mvy, scaleX, scaleY, d.primitives[i]);
@@ -6134,8 +6135,8 @@ export class LineSegment2D {
               public name:string) {
       this.minX = Math.min(this.data[0], this.data[2]);
       this.maxX = Math.max(this.data[0], this.data[2]);
-      this.minY = Math.min(-this.data[1], -this.data[3]);
-      this.maxY = Math.max(-this.data[1], -this.data[3]);
+      this.minY = Math.min(this.data[1], this.data[3]);
+      this.maxY = Math.max(this.data[1], this.data[3]);
   }
 
   public static deserialize(serialized) {
@@ -6143,7 +6144,9 @@ export class LineSegment2D {
     var default_dict_ = {edge_style:default_edge_style};
     serialized = set_default_values(serialized, default_dict_);
     var edge_style = EdgeStyle.deserialize(serialized['edge_style']);
-    return new LineSegment2D(serialized['data'],
+    var data = serialized['data'];
+    [data[1], data[3]] = [-data[1], -data[3]];
+    return new LineSegment2D(data,
                              edge_style,
                              serialized['type_'],
                              serialized['name']);
@@ -6154,9 +6157,9 @@ export class LineSegment2D {
     context.strokeStyle = this.edge_style.color_stroke;
     context.setLineDash(this.edge_style.dashline);
     if (first_elem) {
-      context.moveTo(scaleX*(1000*this.data[0]+ mvx) + X, scaleY*(-1000*this.data[1]+ mvy) + Y);
+      context.moveTo(scaleX*(1000*this.data[0]+ mvx) + X, scaleY*(1000*this.data[1]+ mvy) + Y);
     }
-    context.lineTo(scaleX*(1000*this.data[2]+ mvx) + X, scaleY*(-1000*this.data[3]+ mvy) + Y);
+    context.lineTo(scaleX*(1000*this.data[2]+ mvx) + X, scaleY*(1000*this.data[3]+ mvy) + Y);
   }
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1883,6 +1883,12 @@ export abstract class PlotData {
     }
   }
 
+  merge_alert() {
+    if (this.mergeON) {
+      alert('Warning: point merge is enabled. Therefore, only float attributes will be displayed on tooltips.')
+    }
+  }
+
   reset_scales(): void {
     this.init_scale = Math.min(this.width/(this.coeff_pixel*this.maxX - this.coeff_pixel*this.minX), this.height/(this.coeff_pixel*this.maxY - this.coeff_pixel*this.minY));
     this.scale = this.init_scale;
@@ -3860,7 +3866,7 @@ export class PlotScatter extends PlotData {
     public Y: number,
     public canvas_id: string) {
       super(data, width, height, coeff_pixel, buttons_ON, X, Y, canvas_id);
-      var requirement = '0.4.10';
+      var requirement = '0.5.10';
       check_package_version(data['package_version'], requirement);
       if (this.buttons_ON) {
         this.refresh_buttons_coords();
@@ -3897,6 +3903,7 @@ export class PlotScatter extends PlotData {
         this.scatter_init_points = this.plotObject.point_list;
         this.refresh_MinMax(this.plotObject.point_list);
       }
+      this.merge_alert();
       this.isParallelPlot = false;
   }
 
@@ -6824,7 +6831,6 @@ export class Scatter {
     this.initialize_to_display_attributes();
     this.initialize_lists();
     this.initialize_point_list(elements);
-
   }
 
   public static deserialize(serialized) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1318,7 +1318,7 @@ export class MultiplePlots {
 
   manage_selected_point_index_changes(old_selected_index:number[]) {
     if (!equals(old_selected_index, this.selected_point_index)) {
-      var evt = new CustomEvent('selectionchange', { detail: { 'selected_point_indices': this.selected_point_index } });
+      var evt = new CustomEvent('selectionchange', { detail: { 'selected_point_indices': this.dep_selected_points_index } });
       this.canvas.dispatchEvent(evt);
     }
   }
@@ -8329,7 +8329,7 @@ export function equals(a, b) {
 
 
 const empty_container = {'name': '',
-'package_version': '0.5.9',
+'package_version': '0.5.10',
 'primitive_groups': [],
 'type_': 'primitivegroupcontainer'};
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -6636,21 +6636,17 @@ export class Tooltip {
     return [textfills, text_max_length];
   }
 
-  initialize_text_mergeON(context, x_nb_digits, y_nb_digits, elt, point): [string[], number] {
+  initialize_text_mergeON(context, x_nb_digits, y_nb_digits, elt): [string[], number] {
     var textfills = [];
     var text_max_length = 0;
     for (let i=0; i<this.to_disp_attribute_names.length; i++) {
       let attribute_name = this.to_disp_attribute_names[i];
       let attribute_type = TypeOf(elt[attribute_name]);
       if (attribute_type == 'float') {
-        if (i==0) {
-          var text = attribute_name + ' : ' + MyMath.round(point.cx, Math.max(x_nb_digits, y_nb_digits,2));
-        } else {
-          var text = attribute_name + ' : ' + MyMath.round(-point.cy, Math.max(x_nb_digits, y_nb_digits,2));
-        }
+        var text = attribute_name + ' : ' + MyMath.round(elt[attribute_name], Math.max(x_nb_digits, y_nb_digits,2)); //x_nb_digits évidemment pas définie lorsque l'axe des x est un string...
+        var text_w = context.measureText(text).width;
+        textfills.push(text);
       }
-      var text_w = context.measureText(text).width;
-      textfills.push(text);
       if (text_w > text_max_length) {
         text_max_length = text_w;
       }
@@ -6666,7 +6662,7 @@ export class Tooltip {
       var index = point.getPointIndex(point_list);
       var elt = elements[index];
       if (mergeON === true) {
-        [textfills, text_max_length] = this.initialize_text_mergeON(context, x_nb_digits, y_nb_digits, elt, point);
+        [textfills, text_max_length] = this.initialize_text_mergeON(context, x_nb_digits, y_nb_digits, elt);
       } else {
         [textfills, text_max_length] = this.initialize_text_mergeOFF(context, x_nb_digits, y_nb_digits, elt);
       }
@@ -6833,7 +6829,8 @@ export class Scatter {
 
   public static deserialize(serialized) {
     let default_point_style = {color_fill: string_to_rgb('lightviolet'), color_stroke: string_to_rgb('lightgrey')}
-    var default_dict_ = {point_style:default_point_style}
+    let default_tooltip = {to_disp_attribute_names: serialized['to_disp_attribute_names']}
+    var default_dict_ = {point_style:default_point_style, tooltip: default_tooltip};
     serialized = set_default_values(serialized, default_dict_);
     var axis = Axis.deserialize(serialized['axis']);
     var tooltip = Tooltip.deserialize(serialized['tooltip']);

--- a/src/core.ts
+++ b/src/core.ts
@@ -1883,11 +1883,6 @@ export abstract class PlotData {
     }
   }
 
-  merge_alert() {
-    if (this.mergeON) {
-      alert('Warning: point merge is enabled. Therefore, only float attributes will be displayed on tooltips.')
-    }
-  }
 
   reset_scales(): void {
     this.init_scale = Math.min(this.width/(this.coeff_pixel*this.maxX - this.coeff_pixel*this.minX), this.height/(this.coeff_pixel*this.maxY - this.coeff_pixel*this.minY));
@@ -3904,8 +3899,10 @@ export class PlotScatter extends PlotData {
         this.scatter_init_points = this.plotObject.point_list;
         this.refresh_MinMax(this.plotObject.point_list);
       }
-      this.merge_alert();
       this.isParallelPlot = false;
+      if (this.mergeON && alert_count === 0) {
+        merge_alert();
+      }
   }
 
   draw(hidden, mvx, mvy, scaleX, scaleY, X, Y) {
@@ -8232,6 +8229,13 @@ export function check_package_version(package_version:string, requirement:string
   if (package_version_num < requirement_num) {
     alert("plot_data's version must be updated. Current version: " + package_version + ", minimum requirement: " + requirement);
   }
+}
+
+var alert_count = 0;
+
+export function merge_alert() {
+  alert('Note: when point merge option is enabled, only float attributes will be displayed in tooltips.')
+  alert_count++;
 }
 
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -247,10 +247,12 @@ export class MultiplePlots {
 
   initialize_new_plot_data(new_plot_data:PlotData) {
     this.initializeObjectContext(new_plot_data);
-    new_plot_data.point_families.push(this.point_families[0]);
+    new_plot_data.point_families = this.point_families;    
     if (new_plot_data.type_ == 'scatterplot') {
-      for (let i=0; i<new_plot_data.plotObject.point_list.length; i++) {
-        new_plot_data.plotObject.point_list[i].point_families.push(this.point_families[0]);
+      for (let family of this.point_families) {
+        for (let index of family.point_index) {
+            new_plot_data.plotObject.point_list[index].point_families.push(family);
+        }
       }
     }
     this.objectList.push(new_plot_data);
@@ -431,6 +433,8 @@ export class MultiplePlots {
         this.to_display_plots[i]--;
       }
     }
+    this.clickedPlotIndex = -1; 
+    this.move_plot_index = -1;
   }
 
   getObjectIndex(x, y): number[] {


### PR DESCRIPTION
- Primitive group's "in canvas check" : bug fix
- PrimitiveGroupContainer.primitive_groups can now take lists of primitives (ex: primitive_groups = [[circle, line], [arc, linesegment]]). There is no need to instanciate a PrimitiveGroup every time (though it still works). This is done inside PrimitiveGroupContainer's init