### PR TITLE
fix(multiplot): remove coords from init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3]
+
+### Fixes
+
+- Multiplot : Remove coords from serialization to fix inital_view_on = False issue
+
+
 ## [0.17.0]
 ### Fixes
 - Handle empty elements in Scatter

--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -1382,7 +1382,6 @@ class MultiplePlots(Figure):
         self.elements = sampled_elements
         self.plots = plots
         self.sizes = sizes
-        self.coords = coords
         self.point_families = point_families
         self.initial_view_on = True
         super().__init__(width=width, height=height, type_='multiplot', name=name)

--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -1381,7 +1381,6 @@ class MultiplePlots(Figure):
                 raise ValueError(f"Element of type '{type(element)}' cannot be used as a MultiPlot data element.")
         self.elements = sampled_elements
         self.plots = plots
-        self.sizes = sizes
         self.point_families = point_families
         self.initial_view_on = True
         super().__init__(width=width, height=height, type_='multiplot', name=name)

--- a/script/multiplot.py
+++ b/script/multiplot.py
@@ -69,13 +69,14 @@ histogram3 = plot_data.Histogram(x_variable='color')
 
 # Creating the multiplot
 plots = [parallelplot1, scatterplot1]
-plots2 = [parallelplot1, parallelplot2, scatterplot1, scatterplot2, scatterplot3, graph2d, primitive_group_container,
-          histogram]
+plots2 = [parallelplot1, parallelplot2]
 # multiplot = plot_data.MultiplePlots(plots=plots, elements=elements, initial_view_on=True)
 plot_data_object = plot_data.MultiplePlots(plots=plots2, elements=elements, initial_view_on=True,
                                            point_families=[plot_data.PointFamily('rgb(25, 178, 200)', [1,2,3,4,5,6,7]),
                                                            plot_data.PointFamily('rgb(225, 13, 200)', [10,20,30,41,45,46,47]),
-                                                           plot_data.PointFamily('rgb(146, 178, 78)', [11,21,31,41,25,26,27])])
+                                                           plot_data.PointFamily('rgb(146, 178, 78)', [11,21,31,41,25,26,27])],
+                                           sizes=[plot_data.Window(100, 100), plot_data.Window(100, 100)],
+                                           coords=[(0, 0), (150, 150)])
 
 # Display
 plot_data_object.plot(debug_mode=True, canvas_id='canvas')

--- a/script/multiplot.py
+++ b/script/multiplot.py
@@ -69,7 +69,8 @@ histogram3 = plot_data.Histogram(x_variable='color')
 
 # Creating the multiplot
 plots = [parallelplot1, scatterplot1]
-plots2 = [parallelplot1, parallelplot2]
+plots2 = [parallelplot1, parallelplot2, scatterplot1, scatterplot2, scatterplot3, graph2d, primitive_group_container,
+          histogram]
 # multiplot = plot_data.MultiplePlots(plots=plots, elements=elements, initial_view_on=True)
 plot_data_object = plot_data.MultiplePlots(plots=plots2, elements=elements, initial_view_on=True,
                                            point_families=[plot_data.PointFamily('rgb(25, 178, 200)', [1,2,3,4,5,6,7]),


### PR DESCRIPTION
In order to avoid porting this to all versions until 0.20, I propose to only support 0.17 from now on.

I get it should be fixed naturally by new versions so there is normally no need to port this to dev 