### PR TITLE
Fix LineSegment edge_style when using mpl_plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to directly specify if axes are on or off in Python
 
 ### Fix
-- LineSegment2D : If it is overloaded, MPL Plot now show the right edge_style instead of generating of random one 
+- LineSegment2D : If it is overloaded, MPL Plot now show the right edge_style instead of generating of random one
 
 
 ## [0.23.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1]
+
+### Fix
+
+- LineSegment2D : If it is overloaded, MPL Plot now show the right edge_style instead of generating of random one 
+
 ## [0.23.0]
 
 ### Feat

--- a/plot_data/core.py
+++ b/plot_data/core.py
@@ -494,7 +494,6 @@ class Line2D(ReferencedObject):
         if ax is None:
             _, ax = plt.subplots()
 
-        style = self.edge_style
         if edge_style:
             style = edge_style
             color = style.color_stroke.rgb
@@ -525,9 +524,8 @@ class LineSegment2D(ReferencedObject):
         self.point2 = point2
 
         if edge_style is None:
-            self.edge_style = EdgeStyle()
-        else:
-            self.edge_style = edge_style
+            edge_style = EdgeStyle()
+        self.edge_style = edge_style
         super().__init__(type_='linesegment2d', reference_path=reference_path, name=name)
 
     def bounding_box(self):
@@ -546,10 +544,11 @@ class LineSegment2D(ReferencedObject):
         if not ax:
             _, ax = plt.subplots()
 
-        if edge_style:
-            edge_style = self.edge_style
-        else:
-            edge_style = DEFAULT_EDGESTYLE
+        if edge_style is None:
+            if self.edge_style:
+                edge_style = self.edge_style
+            else:
+                edge_style = DEFAULT_EDGESTYLE
 
         ax.plot([self.point1[0], self.point2[0]], [self.point1[1], self.point2[1]], **edge_style.mpl_arguments(),
                 **kwargs)
@@ -628,7 +627,6 @@ class Circle2D(ReferencedObject):
             edge_style = self.edge_style
         else:
             edge_style = DEFAULT_EDGESTYLE
-            # dashes = DEFAULT_EDGESTYLE.dashline
         args = edge_style.mpl_arguments(surface=True)
         if 'dashes' in args:
             args.pop("dashes")
@@ -670,7 +668,6 @@ class Rectangle(ReferencedObject):
             edge_style = self.edge_style
         else:
             edge_style = DEFAULT_EDGESTYLE
-            # dashes = DEFAULT_EDGESTYLE.dashline
         args = edge_style.mpl_arguments(surface=True)
         if 'dashes' in args:
             args.pop("dashes")


### PR DESCRIPTION
Encountered this while investigating how to generate img from plot_data (Multi Object platform feature)

![image](https://github.com/Dessia-tech/plot_data/assets/42537234/22cd73be-c6df-4b53-96fb-2d23f0cf8f6f)

Expected Result : 

![image](https://github.com/Dessia-tech/plot_data/assets/42537234/e2e28ff5-c26b-41da-823d-704eb6f6ec5a)


There might be other issues with this feature but I just wanted to make sure I could generate some images.
I could have refactor the whole edge_style feature (for other primitives as well), but I didn't want to go this far, as this was just an investigation task and a refactor is already planned